### PR TITLE
add user-provided default constructor to support clang compiler.

### DIFF
--- a/libintrinsic3d/include/nv/sparse_voxel_grid.h
+++ b/libintrinsic3d/include/nv/sparse_voxel_grid.h
@@ -55,6 +55,7 @@ namespace nv
      */
 	struct Voxel
 	{
+        Voxel(){}
         float sdf = 0.0f;
         float weight = 0.0f;
         Vec3b color = Vec3b::Zero();
@@ -67,6 +68,7 @@ namespace nv
      */
 	struct VoxelSBR
 	{
+        VoxelSBR(){}
         double sdf = 0.0;
         float weight = 0.0f;
         Vec3b color = Vec3b::Zero();


### PR DESCRIPTION
/media/capg/WDC4T/zhangchen/intrinsic3d/libintrinsic3d/src/sparse_voxel_grid.cpp:408:17: error:
      default initialization of an object of const type 'const nv::Voxel'
      without a user-provided default constructor
        const T v_init;